### PR TITLE
Add directory-based text editor

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,15 @@
-#root {
-  max-width: 1280px;
+.app {
+  max-width: 800px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 1rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+ul {
+  list-style: none;
+  padding: 0;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+textarea {
+  width: 100%;
+  min-height: 200px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,113 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useState, useEffect } from 'react'
 import './App.css'
+import {
+  pickDirectory,
+  listTextFiles,
+  readFile,
+  writeFile,
+  createFile,
+  deleteFile,
+} from './fileApi'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [dir, setDir] = useState<FileSystemDirectoryHandle | null>(null)
+  const [files, setFiles] = useState<FileSystemFileHandle[]>([])
+  const [current, setCurrent] = useState<FileSystemFileHandle | null>(null)
+  const [content, setContent] = useState('')
+  const [newName, setNewName] = useState('')
+  const [newContent, setNewContent] = useState('')
+
+  const refresh = async (handle: FileSystemDirectoryHandle) => {
+    setFiles(await listTextFiles(handle))
+  }
+
+  const selectDirectory = async () => {
+    const handle = await pickDirectory()
+    if (handle) {
+      setDir(handle)
+      await refresh(handle)
+    }
+  }
+
+  const openFile = async (file: FileSystemFileHandle) => {
+    setContent(await readFile(file))
+    setCurrent(file)
+  }
+
+  const saveFile = async () => {
+    if (current) {
+      await writeFile(current, content)
+      if (dir) await refresh(dir)
+    }
+  }
+
+  const createNewFile = async () => {
+    if (dir && newName) {
+      const file = await createFile(dir, newName, newContent)
+      setNewName('')
+      setNewContent('')
+      await refresh(dir)
+      await openFile(file)
+    }
+  }
+
+  const removeFile = async (file: FileSystemFileHandle) => {
+    if (dir) {
+      await deleteFile(dir, file.name)
+      if (current?.name === file.name) {
+        setCurrent(null)
+        setContent('')
+      }
+      await refresh(dir)
+    }
+  }
+
+  useEffect(() => {
+    if (dir) refresh(dir)
+  }, [dir])
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="app">
+      {!dir && <button onClick={selectDirectory}>Select Directory</button>}
+      {dir && (
+        <div>
+          <h2>Directory: {dir.name}</h2>
+          <button onClick={selectDirectory}>Change Directory</button>
+          <ul>
+            {files.map((f) => (
+              <li key={f.name}>
+                {f.name}{' '}
+                <button onClick={() => openFile(f)}>Open</button>{' '}
+                <button onClick={() => removeFile(f)}>Delete</button>
+              </li>
+            ))}
+          </ul>
+          <div className="new-file">
+            <h3>Create New File</h3>
+            <input
+              placeholder="name.txt"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+            <textarea
+              value={newContent}
+              onChange={(e) => setNewContent(e.target.value)}
+            />
+            <button onClick={createNewFile}>Create</button>
+          </div>
+          {current && (
+            <div className="editor">
+              <h3>Editing {current.name}</h3>
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+              />
+              <button onClick={saveFile}>Save</button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/src/fileApi.d.ts
+++ b/src/fileApi.d.ts
@@ -1,0 +1,11 @@
+export {}
+
+declare global {
+  interface FileSystemDirectoryHandle {
+    entries(): AsyncIterableIterator<[string, FileSystemHandle]>
+  }
+
+  interface Window {
+    showDirectoryPicker(): Promise<FileSystemDirectoryHandle>
+  }
+}

--- a/src/fileApi.ts
+++ b/src/fileApi.ts
@@ -1,0 +1,44 @@
+export async function pickDirectory(): Promise<FileSystemDirectoryHandle | null> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return await (window as any).showDirectoryPicker()
+  } catch (e) {
+    if ((e as DOMException).name === 'AbortError') return null
+    throw e
+  }
+}
+
+export async function listTextFiles(dir: FileSystemDirectoryHandle): Promise<FileSystemFileHandle[]> {
+  const files: FileSystemFileHandle[] = []
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for await (const [name, handle] of (dir as any).entries()) {
+    if (handle.kind === 'file' && (name.endsWith('.txt') || name.endsWith('.md')))
+      files.push(handle as FileSystemFileHandle)
+  }
+  return files
+}
+
+export async function readFile(file: FileSystemFileHandle): Promise<string> {
+  const f = await file.getFile()
+  return f.text()
+}
+
+export async function writeFile(file: FileSystemFileHandle, contents: string): Promise<void> {
+  const writable = await file.createWritable()
+  await writable.write(contents)
+  await writable.close()
+}
+
+export async function createFile(
+  dir: FileSystemDirectoryHandle,
+  name: string,
+  contents: string,
+): Promise<FileSystemFileHandle> {
+  const file = await dir.getFileHandle(name, { create: true })
+  await writeFile(file, contents)
+  return file
+}
+
+export async function deleteFile(dir: FileSystemDirectoryHandle, name: string): Promise<void> {
+  await dir.removeEntry(name)
+}


### PR DESCRIPTION
## Summary
- add `fileApi` module wrapping browser File System Access
- define missing types for `showDirectoryPicker`
- build a simple file manager UI in `App` to view/edit/delete text and markdown
- simplify styling for the new interface

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f1937899883279c59bb465a6e9126